### PR TITLE
feat: add isPartOf (dataset) to output

### DIFF
--- a/src/main/kotlin/no/digdir/servicecatalog/domain/Output.kt
+++ b/src/main/kotlin/no/digdir/servicecatalog/domain/Output.kt
@@ -2,6 +2,7 @@ package no.digdir.servicecatalog.domain
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -11,5 +12,7 @@ data class Output(
     val title: LocalizedStrings?,
     val description: LocalizedStrings?,
     val language: List<String>?,
+    @get:JsonProperty("isPartOf")
+    @param:JsonProperty("isPartOf")
     val isPartOf: List<String>?
 )

--- a/src/main/kotlin/no/digdir/servicecatalog/domain/Output.kt
+++ b/src/main/kotlin/no/digdir/servicecatalog/domain/Output.kt
@@ -10,5 +10,6 @@ data class Output(
     val identifier: String?,
     val title: LocalizedStrings?,
     val description: LocalizedStrings?,
-    val language: List<String>?
+    val language: List<String>?,
+    val isPartOf: List<String>?
 )

--- a/src/main/kotlin/no/digdir/servicecatalog/service/RDFService.kt
+++ b/src/main/kotlin/no/digdir/servicecatalog/service/RDFService.kt
@@ -99,6 +99,7 @@ class RDFService(
                     .addLocalizedStringsAsProperty(DCTerms.title, output.title)
                     .addLocalizedStringsAsProperty(DCTerms.description, output.description)
                     .addStringsAsResources(DCTerms.language, output.language)
+                    .addStringsAsResources(DCTerms.isPartOf, output.isPartOf)
 
                 addProperty(CPSV.produces, outputResource)
             }

--- a/src/test/kotlin/no/digdir/servicecatalog/utils/TestData.kt
+++ b/src/test/kotlin/no/digdir/servicecatalog/utils/TestData.kt
@@ -17,7 +17,8 @@ val SERVICE_0 = ServiceDTO("00", "910244132",
         identifier = "321",
         title = LocalizedStrings(en = "Output title", nb = null, nn = null),
         description = LocalizedStrings(en = "Output description", nb = null, nn = null),
-        language = listOf("http://publications.europa.eu/resource/authority/language/ENG")
+        language = listOf("http://publications.europa.eu/resource/authority/language/ENG"),
+        isPartOf = listOf("http://test.eu/dataset/123")
     )),
     contactPoints = listOf(ContactPoint(
         category = LocalizedStrings(en = "Contact category title", nb = null, nn = null),
@@ -71,7 +72,8 @@ val PUBLIC_SERVICE_0 =
             identifier = "123",
             title = LocalizedStrings(en = "Output title", nb = null, nn = null),
             description = LocalizedStrings(en = "Output description", nb = null, nn = null),
-            language = listOf("http://publications.europa.eu/resource/authority/language/ENG")
+            language = listOf("http://publications.europa.eu/resource/authority/language/ENG"),
+            isPartOf = listOf("http://test.eu/dataset/123")
         )),
         contactPoints = listOf(ContactPoint(
             category = LocalizedStrings(en = "Contact category title", nb = null, nn = null),

--- a/src/test/resources/public_service.ttl
+++ b/src/test/resources/public_service.ttl
@@ -40,6 +40,7 @@
 <http://localhost:5050/rdf/catalogs/910244132/public-services/0/output/123>
         a                cv:Output;
         dct:description  "Output description"@en;
+        dct:isPartOf     <http://test.eu/dataset/123>;
         dct:language     <http://publications.europa.eu/resource/authority/language/ENG>;
         dct:title        "Output title"@en .
 

--- a/src/test/resources/service.ttl
+++ b/src/test/resources/service.ttl
@@ -37,6 +37,7 @@
 <http://localhost:5050/rdf/catalogs/910244132/services/00/output/321>
         a                cv:Output;
         dct:description  "Output description"@en;
+        dct:isPartOf     <http://test.eu/dataset/123>;
         dct:language     <http://publications.europa.eu/resource/authority/language/ENG>;
         dct:title        "Output title"@en .
 

--- a/src/test/resources/service_catalog.ttl
+++ b/src/test/resources/service_catalog.ttl
@@ -51,6 +51,7 @@
 <http://localhost:5050/rdf/catalogs/910244132/public-services/0/output/123>
         a                cv:Output;
         dct:description  "Output description"@en;
+        dct:isPartOf     <http://test.eu/dataset/123>;
         dct:language     <http://publications.europa.eu/resource/authority/language/ENG>;
         dct:title        "Output title"@en .
 
@@ -108,5 +109,6 @@
 <http://localhost:5050/rdf/catalogs/910244132/services/00/output/321>
         a                cv:Output;
         dct:description  "Output description"@en;
+        dct:isPartOf     <http://test.eu/dataset/123>;
         dct:language     <http://publications.europa.eu/resource/authority/language/ENG>;
         dct:title        "Output title"@en .


### PR DESCRIPTION
  - Legg til dataset (dct:isPartOf) på Output-domenemodellen
  - Serialiser dct:isPartOf på cv:Output i RDFService 
  - Oppdater testdata og RDF-fixturer