### PR TITLE
feat: add type to output

### DIFF
--- a/src/main/kotlin/no/digdir/servicecatalog/domain/Output.kt
+++ b/src/main/kotlin/no/digdir/servicecatalog/domain/Output.kt
@@ -14,5 +14,6 @@ data class Output(
     val language: List<String>?,
     @get:JsonProperty("isPartOf")
     @param:JsonProperty("isPartOf")
-    val isPartOf: List<String>?
+    val isPartOf: List<String>?,
+    val type: List<String>?
 )

--- a/src/main/kotlin/no/digdir/servicecatalog/service/RDFService.kt
+++ b/src/main/kotlin/no/digdir/servicecatalog/service/RDFService.kt
@@ -100,6 +100,7 @@ class RDFService(
                     .addLocalizedStringsAsProperty(DCTerms.description, output.description)
                     .addStringsAsResources(DCTerms.language, output.language)
                     .addStringsAsResources(DCTerms.isPartOf, output.isPartOf)
+                    .addStringsAsResources(DCTerms.type, output.type)
 
                 addProperty(CPSV.produces, outputResource)
             }

--- a/src/test/kotlin/no/digdir/servicecatalog/utils/TestData.kt
+++ b/src/test/kotlin/no/digdir/servicecatalog/utils/TestData.kt
@@ -18,7 +18,8 @@ val SERVICE_0 = ServiceDTO("00", "910244132",
         title = LocalizedStrings(en = "Output title", nb = null, nn = null),
         description = LocalizedStrings(en = "Output description", nb = null, nn = null),
         language = listOf("http://publications.europa.eu/resource/authority/language/ENG"),
-        isPartOf = listOf("http://test.eu/dataset/123")
+        isPartOf = listOf("http://test.eu/dataset/123"),
+        type = listOf("https://data.norge.no/vocabulary/service-output-type#declaration")
     )),
     contactPoints = listOf(ContactPoint(
         category = LocalizedStrings(en = "Contact category title", nb = null, nn = null),
@@ -73,7 +74,8 @@ val PUBLIC_SERVICE_0 =
             title = LocalizedStrings(en = "Output title", nb = null, nn = null),
             description = LocalizedStrings(en = "Output description", nb = null, nn = null),
             language = listOf("http://publications.europa.eu/resource/authority/language/ENG"),
-            isPartOf = listOf("http://test.eu/dataset/123")
+            isPartOf = listOf("http://test.eu/dataset/123"),
+            type = listOf("https://data.norge.no/vocabulary/service-output-type#declaration")
         )),
         contactPoints = listOf(ContactPoint(
             category = LocalizedStrings(en = "Contact category title", nb = null, nn = null),

--- a/src/test/resources/public_service.ttl
+++ b/src/test/resources/public_service.ttl
@@ -42,7 +42,8 @@
         dct:description  "Output description"@en;
         dct:isPartOf     <http://test.eu/dataset/123>;
         dct:language     <http://publications.europa.eu/resource/authority/language/ENG>;
-        dct:title        "Output title"@en .
+        dct:title        "Output title"@en ;
+        dct:type         <https://data.norge.no/vocabulary/service-output-type#declaration> .
 
 <http://localhost:5050/rdf/catalogs/910244132/public-services/0/evidence/342549912>
         a                cpsvno:RequiredEvidence;

--- a/src/test/resources/service.ttl
+++ b/src/test/resources/service.ttl
@@ -39,7 +39,8 @@
         dct:description  "Output description"@en;
         dct:isPartOf     <http://test.eu/dataset/123>;
         dct:language     <http://publications.europa.eu/resource/authority/language/ENG>;
-        dct:title        "Output title"@en .
+        dct:title        "Output title"@en ;
+        dct:type         <https://data.norge.no/vocabulary/service-output-type#declaration> .
 
 <http://localhost:5050/rdf/catalogs/910244132/services/00/evidence/342549912>
         a                cpsvno:RequiredEvidence;

--- a/src/test/resources/service_catalog.ttl
+++ b/src/test/resources/service_catalog.ttl
@@ -53,7 +53,8 @@
         dct:description  "Output description"@en;
         dct:isPartOf     <http://test.eu/dataset/123>;
         dct:language     <http://publications.europa.eu/resource/authority/language/ENG>;
-        dct:title        "Output title"@en .
+        dct:title        "Output title"@en ;
+        dct:type         <https://data.norge.no/vocabulary/service-output-type#declaration> .
 
 <http://localhost:5050/rdf/catalogs/910244132>
         a                       dcat:Catalog;
@@ -111,4 +112,5 @@
         dct:description  "Output description"@en;
         dct:isPartOf     <http://test.eu/dataset/123>;
         dct:language     <http://publications.europa.eu/resource/authority/language/ENG>;
-        dct:title        "Output title"@en .
+        dct:title        "Output title"@en ;
+        dct:type         <https://data.norge.no/vocabulary/service-output-type#declaration> .


### PR DESCRIPTION
# Summary

- Legg til type (dct:type) på Output-domenemodellen
- Serialiser dct:type på cv:Output i RDFService
- Oppdater testdata og RDF-fixturer

Del av #1930 (type på mulig tjenesteresultat).